### PR TITLE
fix(unplugin): vite build output css

### DIFF
--- a/.changeset/shaggy-planets-give.md
+++ b/.changeset/shaggy-planets-give.md
@@ -1,0 +1,6 @@
+---
+'@pandabox/unplugin': patch
+---
+
+output a final css once all modules have been loaded by tapping into the generateBundle hook and updating the CSS source
+with parsed PandaContext which contains all loaded modules.


### PR DESCRIPTION
output a final css once all modules have been loaded by tapping into the `generateBundle` hook and updating the CSS source with parsed PandaContext which contains all loaded modules.

> [!NOTE]  
> This only works for the Vite flavor of Unplugin.

Fixes #63