### PR TITLE
fix(unplugin): HMR support

### DIFF
--- a/.changeset/cool-months-smile.md
+++ b/.changeset/cool-months-smile.md
@@ -1,0 +1,5 @@
+---
+"@pandabox/unplugin": patch
+---
+
+hmr support for virtual module

--- a/packages/unplugin/src/plugin/core.ts
+++ b/packages/unplugin/src/plugin/core.ts
@@ -115,15 +115,7 @@ export const unpluginFactory: UnpluginFactory<PandaPluginOptions | undefined> = 
     if (outfile !== ids.css.resolved) {
       getCtx().then((ctx) => fs.writeFile(outfile, ctx.toCss(ctx.panda.createSheet(), options)))
     }
-
-    const timestamp = Date.now()
-    server.moduleGraph.invalidateModule(mod, new Set(), timestamp, true)
-    server.hot.send({
-      type: `${mod.type}-update` as any,
-      path: mod.url,
-      acceptedPath: mod.url,
-      timestamp,
-    } as any)
+    server.reloadModule(mod)
   }
 
   return {


### PR DESCRIPTION
Sending HMR updates manually with `server.moduleGraph` and `server.hot` seems to be the issue. By switching these to `server.reloadModule` updates appear to be loaded and sent properly to the browser. This works for both outfile and virtual module flavors.

Relevant Vite PR: https://github.com/vitejs/vite/pull/10333

I think we also need to debounce this a bit, maybe 100ms. When loading a large graph (like hundreds of files) I noticed HMR updates happening frequently (as expected). Need to play around with this in a separate PR, but this should fix HMR in general.

Fixes:
1. Subsequent HMR updates are properly sent. 
2. Initial load is more accurate, reflecting the current state. However, there were some rare cases where it wouldn't load on the initial startup, maybe 10% of the time. 

### Current State

1. Styles don't load at all for imported dependencies. (non-entry points)
2. Subsequent updates may or may not make it through HMR without a full page reload.

![hmr-broken](https://github.com/user-attachments/assets/932538d6-f567-44a4-a89e-7635f5e6cafc)

### Proposed

1. Notice that imported styles are now available on load.
2. Additional updates are properly hot-updated.

![hmr-fixed](https://github.com/user-attachments/assets/e56e34c0-0fe0-43c9-ba9c-cb8efb3bc9aa)

Also, it looks like @anubra266 was also looking for a solution a while back.
https://github.com/patak-dev/vite-plugin-virtual/issues/6

FYI looks like Vite does the `invalidateModule` behind the scenes when invoking this function
![image](https://github.com/user-attachments/assets/5708e74f-4ffb-48a1-a6ff-13b902dfd772)


Fixes #67
