### PR TITLE
Fix compatibility with Windows paths and reduce update CSS calls

### DIFF
--- a/.changeset/fast-spies-unite.md
+++ b/.changeset/fast-spies-unite.md
@@ -1,0 +1,5 @@
+---
+"@pandabox/unplugin": patch
+---
+
+Reduce update CSS calls

--- a/.changeset/gorgeous-readers-lay.md
+++ b/.changeset/gorgeous-readers-lay.md
@@ -1,0 +1,5 @@
+---
+"@pandabox/unplugin": patch
+---
+
+Avoid generating output file if no changes

--- a/.changeset/healthy-tomatoes-matter.md
+++ b/.changeset/healthy-tomatoes-matter.md
@@ -1,0 +1,5 @@
+---
+"@pandabox/unplugin": patch
+---
+
+Fix compatibility with Windows paths

--- a/packages/unplugin/src/plugin/core.ts
+++ b/packages/unplugin/src/plugin/core.ts
@@ -136,16 +136,12 @@ export const unpluginFactory: UnpluginFactory<PandaPluginOptions | undefined> = 
       await fs.writeFile(outfile, css)
     } else {
       if (!server) return
-      const mod = server.moduleGraph.getModuleById(outfile.replaceAll("\\", "/"))
+      const mod = server.moduleGraph.getModuleById(outfile.replaceAll('\\', '/'))
       if (!mod) return
       await server.reloadModule(mod)
     }
   }
-  const requestUpdateCss = throttle(
-    updateCss,
-    throttleWaitMs,
-    { edges: ['leading', 'trailing'] },
-  )
+  const requestUpdateCss = throttle(updateCss, throttleWaitMs, { edges: ['leading', 'trailing'] })
   return {
     name: 'unplugin-panda',
     enforce: 'pre',

--- a/packages/unplugin/src/plugin/core.ts
+++ b/packages/unplugin/src/plugin/core.ts
@@ -131,7 +131,7 @@ export const unpluginFactory: UnpluginFactory<PandaPluginOptions | undefined> = 
   let throttledReloadModule: (mod: ModuleNode) => void
   const updateCss = (_file: string) => {
     if (!server) return
-    const mod = server.moduleGraph.getModuleById(outfile)
+    const mod = server.moduleGraph.getModuleById(outfile.replaceAll("\\", "/"))
     if (!mod) return
 
     // console.log('invalidate', { from: file })

--- a/packages/unplugin/src/plugin/core.ts
+++ b/packages/unplugin/src/plugin/core.ts
@@ -125,6 +125,7 @@ export const unpluginFactory: UnpluginFactory<PandaPluginOptions | undefined> = 
   }
 
   let server: ViteDevServer
+  let lastCss: string | undefined
   /**
    * Throttle HMR updates to vite server
    */
@@ -133,7 +134,10 @@ export const unpluginFactory: UnpluginFactory<PandaPluginOptions | undefined> = 
     if (outfile !== ids.css.resolved) {
       const ctx = await getCtx()
       const css = await ctx.toCss(ctx.panda.createSheet(), options)
-      await fs.writeFile(outfile, css)
+      if (lastCss !== css) {
+        lastCss = css
+        await fs.writeFile(outfile, css)
+      }
     } else {
       if (!server) return
       const mod = server.moduleGraph.getModuleById(outfile.replaceAll('\\', '/'))


### PR DESCRIPTION
If you update the CSS file (`fs.writeFile`) no need to reload the module because vite will detect the change.