### PR TITLE
Fix outfile build

### DIFF
--- a/.changeset/small-penguins-enjoy.md
+++ b/.changeset/small-penguins-enjoy.md
@@ -1,0 +1,5 @@
+---
+"@pandabox/unplugin": patch
+---
+
+Fix outfile build

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,3 @@
+{
+  "recommendations": ["esbenp.prettier-vscode"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,10 @@
+{
+  "editor.formatOnSave": true,
+  "editor.defaultFormatter": "esbenp.prettier-vscode",
+  "[typescript]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  },
+  "[typescriptreact]": {
+    "editor.defaultFormatter": "esbenp.prettier-vscode"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "define-theme": "pnpm --filter @pandabox/define-theme",
     "knip": "knip",
     "release": "changeset publish",
-    "fmt": "prettier --write {packages}/**/*.{ts,tsx}",
+    "fmt": "prettier --write packages/**/*.{ts,tsx}",
     "dev": "pnpm --parallel --filter=./packages/* dev",
     "build": "pnpm --filter @pandabox/* run build",
     "typecheck": "pnpm --filter @pandabox/* run typecheck",

--- a/packages/define-theme/sandbox/preset-base/patterns.ts
+++ b/packages/define-theme/sandbox/preset-base/patterns.ts
@@ -164,8 +164,8 @@ const grid = definePattern({
         columns != null
           ? map(columns, (v) => `repeat(${v}, minmax(0, 1fr))`)
           : minChildWidth != null
-          ? map(minChildWidth, (v) => `repeat(auto-fit, minmax(${getValue(v)}, 1fr))`)
-          : undefined,
+            ? map(minChildWidth, (v) => `repeat(auto-fit, minmax(${getValue(v)}, 1fr))`)
+            : undefined,
       gap,
       columnGap,
       rowGap,

--- a/packages/prettier-plugin/tsup.config.ts
+++ b/packages/prettier-plugin/tsup.config.ts
@@ -3,5 +3,5 @@ import { defineConfig } from 'tsup'
 export default defineConfig({
   entry: ['src/index.ts'],
   format: ['cjs'],
-  clean: true
+  clean: true,
 })

--- a/packages/unplugin/src/plugin/create-context.ts
+++ b/packages/unplugin/src/plugin/create-context.ts
@@ -62,7 +62,7 @@ export const createContext = (options: ContextOptions) => {
 
       // logger.info('ctx:updated', 'config rebuilt ✅')
       await panda.hooks['config:change']?.({ config: panda.config, changes: affecteds })
-      if(options.codegen) {
+      if (options.codegen) {
         await codegen(panda, Array.from(affecteds.artifacts))
       }
 

--- a/packages/utils/src/wrap-value.ts
+++ b/packages/utils/src/wrap-value.ts
@@ -2,15 +2,15 @@
  * Recursively wraps each value in a { value: xxx } object
  */
 export const wrapValue = (obj: Record<string, any>) => {
-	const newObj: Record<string, any> = {}
+  const newObj: Record<string, any> = {}
 
-	for (const key in obj) {
-		if (typeof obj[key] === 'object' && !Array.isArray(obj[key])) {
-			newObj[key] = wrapValue(obj[key]) // Recursive call for nested objects
-		} else {
-			newObj[key] = { value: obj[key] }
-		}
-	}
+  for (const key in obj) {
+    if (typeof obj[key] === 'object' && !Array.isArray(obj[key])) {
+      newObj[key] = wrapValue(obj[key]) // Recursive call for nested objects
+    } else {
+      newObj[key] = { value: obj[key] }
+    }
+  }
 
-	return newObj
+  return newObj
 }


### PR DESCRIPTION
Currently, the build is calling `ctx.panda.parseFiles()` to parse the files, so `options.transform` will have no effect.

Also, during the build the CSS file is being updated in the transformations and this can cause inconsistencies in the output file due to race conditions.