### PR TITLE
fix(unplugin): parse buildinfo file

### DIFF
--- a/.changeset/itchy-worms-refuse.md
+++ b/.changeset/itchy-worms-refuse.md
@@ -1,0 +1,5 @@
+---
+"@pandabox/unplugin": patch
+---
+
+Parse the `panda.buildinfo.json` files.

--- a/packages/unplugin/src/plugin/core.ts
+++ b/packages/unplugin/src/plugin/core.ts
@@ -260,7 +260,13 @@ export const unpluginFactory: UnpluginFactory<PandaPluginOptions | undefined> = 
           let prevState = updateCssOnTransform
           updateCssOnTransform = false
           try {
-            for (const file of ctx.panda.getFiles()) await server.transformRequest(file)
+            for (const file of ctx.panda.getFiles()) {
+              if (path.basename(file) === 'panda.buildinfo.json') {
+                ctx.panda.project.parseSourceFile(file)
+              } else {
+                await server.transformRequest(file)
+              }
+            }
           } finally {
             updateCssOnTransform = prevState
           }


### PR DESCRIPTION
This bug was introduced in v0.2.1.

PandaCSS allows adding `panda.buildinfo.json` files to the configuration, but these files are no longer parsed in v0.2.1.